### PR TITLE
Replace pynput with selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 ## Libraries
 * Selenium - webdriver :gear:
 * Time :clock1:
-* pynput :computer:
 
 
 ## Project
@@ -25,7 +24,7 @@
 
 	The drawn board is then passed through a sudoku solver, finally returning a solution 
 
-	This solution is then entered into the https://www.livesudoku.com/ site with the help of xpath, selenium and pynput.
+	This solution is then entered into the https://www.livesudoku.com/ site with the help of xpath, and selenium.
 	
 	
 ## Getting Started!
@@ -34,10 +33,6 @@
 	- ensure libraries are working properly
 	- clone repository
 	- run the projuct from Sudoku_Main.py
-	
-## Glaring Issue.
-* When the site(https://www.livesudoku.com/) loses focus pynput isnt able to enter the sudoku values in their 				respective squares. To circumvent this issue the project is written in such a way that after necessary data is collected from the user, so long as they don't remove focus from the site everything works accordingly. BUT this is obviously a band-aid solution to the problem.
-
 
 ### **:sun_with_face: Feel free to fork this repository and extend the capabilities of the project! :sun_with_face:**
 	

--- a/Sudoku_Keyboard.py
+++ b/Sudoku_Keyboard.py
@@ -1,11 +1,7 @@
-from pynput.keyboard import Key, Controller
+from selenium.webdriver.common.action_chains import ActionChains
 from time import sleep
 
-keyboard = Controller()
 
+def keyboard_usage(driver, value):
+    ActionChains(driver).key_down(value).pause(0.5).key_up(value).pause(0.5).perform()
 
-def keyboard_usage(value):
-    keyboard.press(value)
-    sleep(0.5)
-    keyboard.release(value)
-    sleep(0.5)

--- a/Sudoku_Site_Scraper_Entry.py
+++ b/Sudoku_Site_Scraper_Entry.py
@@ -47,4 +47,4 @@ def value_entry(driver, solved):
     for i in entry_list_confirm:
         empty_id(i, driver)
         sleep(0.5)
-        keyboard_usage(solution_list[entry_list_confirm.index(i)])
+        keyboard_usage(driver, solution_list[entry_list_confirm.index(i)])


### PR DESCRIPTION
Replace the `pynput` library with [`selenium` `ActionChains`](https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.common.action_chains).

> Choose ActionChains instead of [WebElement](https://selenium-python.readthedocs.io/api.html#selenium.webdriver.remote.webelement.WebElement) in order not to lose the key-down, pause for half a second, key-up behavior.

Not only removes the `pynput` library as a requirements, but also allows keyboard input without requiring the window to be in focus.